### PR TITLE
port_data: Use a separate socket for reading and writing

### DIFF
--- a/src/port_data.hh
+++ b/src/port_data.hh
@@ -34,7 +34,8 @@ public:
 			   const fd_set *error_fds,
 			   double time_since_last_call);
 private:
-	int fd;
+	int fd_r;
+	int fd_w;
 	int debug;
 	uint32_t src_ip;
 	uint16_t src_port;


### PR DESCRIPTION
Hi!
I am proposing a small update to the ext port-data layer, especially useful if running the titan engine in a VM/docker where the external addresses/ports could be altered by NAT/forwarding...

* The port code is ready to be used with two separate endpoints with different src_ip and dst_ip, but one common UDP socket was used for both of these endpoints. Added a separate fd for reading and writing, so enabling user having a separate source and destination IPs.
* Fixed a minor bug in setting the `src_ip` as a parameter.